### PR TITLE
Example serialization of compound types

### DIFF
--- a/tests/Functional/Container.php
+++ b/tests/Functional/Container.php
@@ -21,6 +21,7 @@ use Symfony\Cmf\Component\ContentType\Metadata\Driver\ArrayDriver;
 use Symfony\Cmf\Component\ContentType\View\ScalarView;
 use Symfony\Cmf\Component\ContentType\ViewRegistry;
 use Symfony\Component\Form\Forms;
+use Symfony\Cmf\Component\ContentType\Tests\Functional\Example\Field\ImageField;
 
 class Container extends PimpleContainer
 {
@@ -54,6 +55,7 @@ class Container extends PimpleContainer
         $this['cmf_content_type.registry.field'] = function ($container) {
             $registry = new FieldRegistry();
             $registry->register('text', new TextField());
+            $registry->register('image', new ImageField());
 
             return $registry;
         };

--- a/tests/Functional/Example/Field/ImageField.php
+++ b/tests/Functional/Example/Field/ImageField.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2016 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Component\ContentType\Tests\Functional\Example\Field;
+
+use Symfony\Cmf\Component\ContentType\FieldInterface;
+use Symfony\Cmf\Component\ContentType\View\ScalarView;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Cmf\Component\ContentType\Tests\Functional\Example\Form\Type\ImageType;
+
+class ImageField implements FieldInterface
+{
+    public function getViewType()
+    {
+        return 'image';
+    }
+
+    public function getFormType()
+    {
+        return ImageType::class;
+    }
+
+    public function configureOptions(OptionsResolver $options)
+    {
+        $options->setDefault('reosurce_path', '/');
+    }
+}

--- a/tests/Functional/Example/Form/Type/ImageType.php
+++ b/tests/Functional/Example/Form/Type/ImageType.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Component\ContentType\Tests\Functional\Example\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+
+class ImageType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->add('path');
+        $builder->add('width', IntegerType::class);
+        $builder->add('height', IntegerType::class);
+        $builder->add('mimetype');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+    }
+}

--- a/tests/Functional/FormBuilderTest.php
+++ b/tests/Functional/FormBuilderTest.php
@@ -40,4 +40,43 @@ class FormBuilderTest extends BaseTestCase
         $form->submit($data);
         $this->assertEquals('Foobar', $article->title);
     }
+
+    public function testCompoundType()
+    {
+        $builder = $this->getContainer([
+            'mapping' => [
+                Article::class => [
+                    'properties' => [
+                        'title' => [
+                            'type' => 'text',
+                        ],
+                        'image' => [
+                            'type' => 'image',
+                        ],
+                    ],
+                ],
+            ],
+        ])->get('cmf_content_type.form_builder');
+
+        $article = new Article();
+        $builder = $builder->buildFormForContent($article);
+        $form = $builder->getForm();
+
+        $imageData = [
+                'height' => 100,
+                'width' => 100,
+                'mimetype' => 'image/jpeg',
+                'path' => 'path/to/foo.png',
+        ];
+        $data = [
+            'title' => 'Hello',
+            'image' => $imageData,
+        ];
+
+        $form->submit($data);
+        $this->assertTrue($form->isValid());
+
+        $this->assertEquals('Hello', $article->title);
+        $this->assertEquals($imageData, unserialize($article->image));
+    }
 }


### PR DESCRIPTION
This PR demonstrates what could be a default behavior of "PHP serialization" of compound types to a single string field.

For example, some CMS systems might store an image list as a string scalar:

```
[
    {
        "path": "path/to/image2.jpg",
        "title": "My Image2"
        "height": 100,
        ...
    },
    {
        "path": "path/to/image2.jpg",
        "title": "My Image2"
        "height": 100,
        ...
    }
]
```

This method takes a similar approach but serialize to PHP.

This method is bad for the following reasons:

- No foreign key relationships.
- Fields are not queryable.

The user should be able to change this behavior to use Doctrine Embeddables or PHPCR sub-objects or another strategy for storing atomic values rather than using serialization.

Another issue is that the Enity/Document, in this implementation, is not aware of the serialization, so if the field is accessed directly from the DTO it will return the serialized data.

This could be addressed at the storage level (e.g. with Doctrine ORM, using a JSON field), but this behavior would provide a lowest-level fallback.
